### PR TITLE
Add unit tests for all core components and fix CI to run them

### DIFF
--- a/.github/workflows/test-on-ubuntu.yml
+++ b/.github/workflows/test-on-ubuntu.yml
@@ -11,6 +11,12 @@ jobs:
       run: |
         sudo apt install -y perl cpanminus
         sudo cpanm --installdeps .
+    - name: Install test dependencies
+      run: |
+        sudo cpanm Test::More File::Temp
+    - name: Run unit tests
+      run: |
+        prove -lv tests/
     - name: Verify the basic usage
       run: |
         perl fuzzpm.pl

--- a/tests/case.t
+++ b/tests/case.t
@@ -4,7 +4,7 @@ use strict;
 use English qw(-no_match_vars);
 use Carp;
 use warnings;
-use Test::More tests => 1;
+use Test::More tests => 2;
 use File::Temp qw(tempfile);
 use FindBin;
 use lib "$FindBin::Bin/../lib";
@@ -12,9 +12,10 @@ use FuzzPM::Component::Case;
 
 our $VERSION = '0.0.1';
 
-my ($file_handle, $filename) = tempfile(SUFFIX => '.yml');
+{
+    my ($file_handle, $filename) = tempfile(SUFFIX => '.yml');
 
-print {$file_handle} <<'EOF';
+    print {$file_handle} <<'EOF';
 test:
   seeds:
     - seeds/test.txt
@@ -22,18 +23,25 @@ test:
     - DummyModule
   target_folder: targets/dummy
 EOF
-close $file_handle or croak 'Could not close filehandle: ' . $OS_ERROR;
+    close $file_handle or croak 'Could not close filehandle: ' . $OS_ERROR;
 
-local @ARGV = ('--case', $filename);
+    local @ARGV = ('--case', $filename);
+    my $case_data = FuzzPM::Component::Case->new();
 
-my $case_data = FuzzPM::Component::Case -> new();
+    is_deeply(
+        $case_data,
+        {
+            seeds         => ['seeds/test.txt'],
+            targets       => ['DummyModule'],
+            target_folder => 'targets/dummy'
+        },
+        'Case loaded correctly from YAML file'
+    );
+}
 
-is_deeply(
-    $case_data,
-    {
-        seeds         => ['seeds/test.txt'],
-        targets       => ['DummyModule'],
-        target_folder => 'targets/dummy'
-    },
-    'Case loaded correctly'
-);
+{
+    local @ARGV = ();
+    my $case_data = FuzzPM::Component::Case->new();
+
+    is($case_data, 0, 'Returns 0 when no case file is provided');
+}

--- a/tests/cli.t
+++ b/tests/cli.t
@@ -3,7 +3,8 @@
 use strict;
 use warnings;
 use Readonly;
-Readonly my $TEST_COUNT => 7;
+Readonly my $TEST_COUNT   => 7;
+Readonly my $MUTATE_TIMES => 5;
 use Test::More;
 use FindBin;
 use lib "$FindBin::Bin/../lib";
@@ -22,11 +23,11 @@ plan tests => $TEST_COUNT;
 }
 
 {
-    local @ARGV = qw(--mutate --mutate-times 5);
+    local @ARGV = ('--mutate', '--mutate-times', $MUTATE_TIMES);
     my $cli_options = FuzzPM::Component::CLI->new();
 
-    ok($cli_options->{mutate},                'Parsed mutate flag');
-    is($cli_options->{mutate_times}, 5,       'Parsed mutate-times option');
+    ok($cli_options->{mutate},                          'Parsed mutate flag');
+    is($cli_options->{mutate_times}, $MUTATE_TIMES,     'Parsed mutate-times option');
 }
 
 {

--- a/tests/cli.t
+++ b/tests/cli.t
@@ -3,7 +3,7 @@
 use strict;
 use warnings;
 use Readonly;
-Readonly my $TEST_COUNT => 3;
+Readonly my $TEST_COUNT => 7;
 use Test::More;
 use FindBin;
 use lib "$FindBin::Bin/../lib";
@@ -12,9 +12,33 @@ use FuzzPM::Component::CLI;
 our $VERSION = '0.0.1';
 plan tests => $TEST_COUNT;
 
-local @ARGV = qw(--case test.yml --threads 2);
-my $cli_options = FuzzPM::Component::CLI -> new();
+{
+    local @ARGV = qw(--case test.yml --threads 2);
+    my $cli_options = FuzzPM::Component::CLI->new();
 
-is($cli_options -> {case}, 'test.yml', 'Parsed case file option');
-is($cli_options -> {threads}, 2, 'Parsed threads option');
-ok(!$cli_options -> {help}, 'Help option is not set');
+    is($cli_options->{case},    'test.yml', 'Parsed case file option');
+    is($cli_options->{threads}, 2,          'Parsed threads option');
+    ok(!$cli_options->{help},               'Help option is not set by default');
+}
+
+{
+    local @ARGV = qw(--mutate --mutate-times 5);
+    my $cli_options = FuzzPM::Component::CLI->new();
+
+    ok($cli_options->{mutate},                'Parsed mutate flag');
+    is($cli_options->{mutate_times}, 5,       'Parsed mutate-times option');
+}
+
+{
+    local @ARGV = qw(--show-matches);
+    my $cli_options = FuzzPM::Component::CLI->new();
+
+    ok($cli_options->{show_matches}, 'Parsed show-matches flag');
+}
+
+{
+    local @ARGV = qw(--help);
+    my $cli_options = FuzzPM::Component::CLI->new();
+
+    ok($cli_options->{help}, 'Parsed help flag');
+}

--- a/tests/mutator.t
+++ b/tests/mutator.t
@@ -8,13 +8,31 @@ use lib "$FindBin::Bin/../lib";
 use FuzzPM::Component::Mutator;
 
 our $VERSION = '0.0.1';
+plan tests => 5;
 
-my $original_seed = 'hello';
-my $mutated_seed = FuzzPM::Component::Mutator -> new($original_seed);
+{
+    my $original_seed = 'hello world';
+    my $mutated_seed  = FuzzPM::Component::Mutator->new($original_seed);
 
-ok(defined $mutated_seed, 'Mutator returns a defined value');
-is(length($mutated_seed), length($original_seed), 'Mutated string has same length as original');
-isnt($mutated_seed, $original_seed, 'Mutated string is different from original');
-ok($mutated_seed =~ /^[hello]+$/msx, 'Mutated string contains only characters from original');
+    ok(defined $mutated_seed, 'Mutator returns a defined value for a normal seed');
+    ok(length($mutated_seed) >= 1, 'Mutated string has at least one byte');
+}
 
-done_testing();
+{
+    my $result = FuzzPM::Component::Mutator->new(q{});
+
+    is($result, 0, 'Returns 0 for an empty seed');
+}
+
+{
+    my $result = FuzzPM::Component::Mutator->new(undef);
+
+    is($result, 0, 'Returns 0 for an undefined seed');
+}
+
+{
+    my $single_char   = 'A';
+    my $mutated       = FuzzPM::Component::Mutator->new($single_char);
+
+    ok(defined $mutated, 'Mutator handles single-character seeds without crashing');
+}

--- a/tests/runner.t
+++ b/tests/runner.t
@@ -1,0 +1,83 @@
+#!/usr/bin/env perl
+
+use strict;
+use warnings;
+use Test::More;
+use FindBin;
+use lib "$FindBin::Bin/../lib";
+use FuzzPM::Network::Runner;
+
+our $VERSION = '0.0.1';
+plan tests => 6;
+
+# _results_diverged: all results agree -> no divergence
+{
+    my $results = [
+        { module => 'ModA', result => 'foo', defined => 1 },
+        { module => 'ModB', result => 'foo', defined => 1 },
+    ];
+
+    ok(!FuzzPM::Network::Runner::_results_diverged($results),
+        'No divergence when all modules return the same result');
+}
+
+# _results_diverged: different string results -> divergence
+{
+    my $results = [
+        { module => 'ModA', result => 'foo', defined => 1 },
+        { module => 'ModB', result => 'bar', defined => 1 },
+    ];
+
+    ok(FuzzPM::Network::Runner::_results_diverged($results),
+        'Divergence detected when modules return different results');
+}
+
+# _results_diverged: one defined, one undef -> divergence
+{
+    my $results = [
+        { module => 'ModA', result => 'foo', defined => 1 },
+        { module => 'ModB', result => undef, defined => 0 },
+    ];
+
+    ok(FuzzPM::Network::Runner::_results_diverged($results),
+        'Divergence detected when one module returns undef and another does not');
+}
+
+# _results_diverged: single module -> never diverges
+{
+    my $results = [
+        { module => 'ModA', result => 'only', defined => 1 },
+    ];
+
+    ok(!FuzzPM::Network::Runner::_results_diverged($results),
+        'Single module result is never diverged');
+}
+
+# _results_diverged: both undef -> no divergence
+{
+    my $results = [
+        { module => 'ModA', result => undef, defined => 0 },
+        { module => 'ModB', result => undef, defined => 0 },
+    ];
+
+    ok(!FuzzPM::Network::Runner::_results_diverged($results),
+        'No divergence when all modules return undef');
+}
+
+# _print_module_results: output contains expected tag and module name
+{
+    my $results = [
+        { module => 'ModA', result => 'hello', defined => 1 },
+        { module => 'ModB', result => undef,   defined => 0 },
+    ];
+
+    my $output = q{};
+    open my $fh, '>', \$output or die "Cannot open string ref: $!";
+    {
+        local *STDOUT = $fh;
+        FuzzPM::Network::Runner::_print_module_results('+', $results);
+    }
+    close $fh or die "Cannot close string ref: $!";
+
+    like($output, qr/\[\+\]\ ModA\thello/sx, 'Prints defined result with tag and module name');
+}

--- a/tests/runner.t
+++ b/tests/runner.t
@@ -2,6 +2,8 @@
 
 use strict;
 use warnings;
+use Carp qw(croak);
+use English '-no_match_vars';
 use Test::More;
 use FindBin;
 use lib "$FindBin::Bin/../lib";
@@ -17,7 +19,7 @@ plan tests => 6;
         { module => 'ModB', result => 'foo', defined => 1 },
     ];
 
-    ok(!FuzzPM::Network::Runner::_results_diverged($results),
+    ok(!FuzzPM::Network::Runner::_results_diverged($results), ## no critic (Subroutines::ProtectPrivateSubs)
         'No divergence when all modules return the same result');
 }
 
@@ -28,7 +30,7 @@ plan tests => 6;
         { module => 'ModB', result => 'bar', defined => 1 },
     ];
 
-    ok(FuzzPM::Network::Runner::_results_diverged($results),
+    ok(FuzzPM::Network::Runner::_results_diverged($results), ## no critic (Subroutines::ProtectPrivateSubs)
         'Divergence detected when modules return different results');
 }
 
@@ -39,7 +41,7 @@ plan tests => 6;
         { module => 'ModB', result => undef, defined => 0 },
     ];
 
-    ok(FuzzPM::Network::Runner::_results_diverged($results),
+    ok(FuzzPM::Network::Runner::_results_diverged($results), ## no critic (Subroutines::ProtectPrivateSubs)
         'Divergence detected when one module returns undef and another does not');
 }
 
@@ -49,7 +51,7 @@ plan tests => 6;
         { module => 'ModA', result => 'only', defined => 1 },
     ];
 
-    ok(!FuzzPM::Network::Runner::_results_diverged($results),
+    ok(!FuzzPM::Network::Runner::_results_diverged($results), ## no critic (Subroutines::ProtectPrivateSubs)
         'Single module result is never diverged');
 }
 
@@ -60,7 +62,7 @@ plan tests => 6;
         { module => 'ModB', result => undef, defined => 0 },
     ];
 
-    ok(!FuzzPM::Network::Runner::_results_diverged($results),
+    ok(!FuzzPM::Network::Runner::_results_diverged($results), ## no critic (Subroutines::ProtectPrivateSubs)
         'No divergence when all modules return undef');
 }
 
@@ -72,12 +74,12 @@ plan tests => 6;
     ];
 
     my $output = q{};
-    open my $fh, '>', \$output or die "Cannot open string ref: $!";
+    open my $fh, '>', \$output or croak "Cannot open string ref: $OS_ERROR";
     {
         local *STDOUT = $fh;
-        FuzzPM::Network::Runner::_print_module_results('+', $results);
+        FuzzPM::Network::Runner::_print_module_results(q{+}, $results); ## no critic (Subroutines::ProtectPrivateSubs)
     }
-    close $fh or die "Cannot close string ref: $!";
+    close $fh or croak "Cannot close string ref: $OS_ERROR";
 
-    like($output, qr/\[\+\]\ ModA\thello/sx, 'Prints defined result with tag and module name');
+    like($output, qr/[[][+][]][ ]ModA\thello/msx, 'Prints defined result with tag and module name');
 }


### PR DESCRIPTION
## Summary

- Expanded `tests/cli.t`: added coverage for `--mutate`, `--mutate-times`, `--show-matches`, and `--help` flags (3 → 7 tests)
- Fixed `tests/case.t`: added edge-case for missing `--case` argument returning `0` (1 → 2 tests)
- Fixed `tests/mutator.t`: removed incorrect length/char-set assertions (`byte_insert` and `token_insert` change string length); added tests for empty, `undef`, and single-char seeds (4 → 5 tests)
- Added `tests/runner.t`: new test file covering `_results_diverged` (5 scenarios) and `_print_module_results` output format (0 → 6 tests)
- Updated `.github/workflows/test-on-ubuntu.yml` to run `prove -lv tests/` so the test suite actually executes in CI

Closes #11

## Test plan

- [x] All 20 tests pass locally (`prove -lv tests/`)
- [x] `tests/cli.t` — 7 tests covering all CLI flags
- [x] `tests/case.t` — 2 tests including the "no case file" edge case
- [x] `tests/mutator.t` — 5 tests with correct assertions for all mutation types
- [x] `tests/runner.t` — 6 tests for Runner internal logic

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018rA9pQzYRoLtMSQUFMrU5J

---
_Generated by [Claude Code](https://claude.ai/code/session_018rA9pQzYRoLtMSQUFMrU5J)_