### PR TITLE
fix(ci): fix TruffleHog base/head inputs for push events

### DIFF
--- a/.github/workflows/secret-scanning.yml
+++ b/.github/workflows/secret-scanning.yml
@@ -30,8 +30,8 @@ jobs:
         continue-on-error: true
         with:
           path: ./
-          base: "${{ github.event.repository.default_branch }}"
-          head: HEAD
+          base: "${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || '' }}"
+          head: "${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || '' }}"
           extra_args: --debug
 
       - name: Scan Results Status


### PR DESCRIPTION
## Summary

- On a `push` to `main`, the previous `base: "${{ github.event.repository.default_branch }}"` and `head: HEAD` resolved to the same commit SHA, causing TruffleHog to fail with _"BASE and HEAD commits are the same. TruffleHog won't scan anything."_
- Fix: populate `base`/`head` only on `pull_request` events (using the PR's actual SHAs); leave them empty on `push` so TruffleHog falls back to its built-in `github.event.before`/`github.event.after` logic.

## Test plan

- [ ] Merge this PR and confirm the Secret Scanning workflow completes successfully on the resulting push to `main`
- [ ] Open a new PR and confirm TruffleHog scans only the changed commits (base → head)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011YTWa1hdAe5M9bwhLWLnZF

---
_Generated by [Claude Code](https://claude.ai/code/session_011YTWa1hdAe5M9bwhLWLnZF)_