### PR TITLE
Replace inline test fixture with external YAML file

### DIFF
--- a/.github/workflows/test-on-ubuntu.yml
+++ b/.github/workflows/test-on-ubuntu.yml
@@ -13,7 +13,7 @@ jobs:
         sudo cpanm --installdeps .
     - name: Install test dependencies
       run: |
-        sudo cpanm Test::More File::Temp
+        sudo cpanm Test::More
     - name: Run unit tests
       run: |
         prove -lv tests/

--- a/cpanfile
+++ b/cpanfile
@@ -5,6 +5,5 @@ requires 'Readonly', '2.05';
 requires 'Try::Tiny', '0.32';
 
 on 'test' => sub {
-    requires 'File::Temp', '0.2312';
-    requires 'FindBin',             '1.54';
+    requires 'FindBin', '1.54';
 }

--- a/tests/case.t
+++ b/tests/case.t
@@ -5,7 +5,6 @@ use English qw(-no_match_vars);
 use Carp;
 use warnings;
 use Test::More tests => 2;
-use File::Temp qw(tempfile);
 use FindBin;
 use lib "$FindBin::Bin/../lib";
 use FuzzPM::Component::Case;
@@ -13,19 +12,9 @@ use FuzzPM::Component::Case;
 our $VERSION = '0.0.1';
 
 {
-    my ($file_handle, $filename) = tempfile(SUFFIX => '.yml');
+    my $fixture = "$FindBin::Bin/fixtures/test_case.yml";
 
-    print {$file_handle} <<'EOF';
-test:
-  seeds:
-    - seeds/test.txt
-  targets:
-    - DummyModule
-  target_folder: targets/dummy
-EOF
-    close $file_handle or croak 'Could not close filehandle: ' . $OS_ERROR;
-
-    local @ARGV = ('--case', $filename);
+    local @ARGV = ('--case', $fixture);
     my $case_data = FuzzPM::Component::Case->new();
 
     is_deeply(

--- a/tests/fixtures/test_case.yml
+++ b/tests/fixtures/test_case.yml
@@ -1,0 +1,6 @@
+test:
+  seeds:
+    - seeds/test.txt
+  targets:
+    - DummyModule
+  target_folder: targets/dummy


### PR DESCRIPTION
## Summary
Refactored the test case to use an external fixture file instead of generating test data inline, improving test maintainability and clarity.

## Key Changes
- Moved hardcoded YAML test data from `tests/case.t` into a new fixture file `tests/fixtures/test_case.yml`
- Updated test to reference the fixture file via `$FindBin::Bin/fixtures/test_case.yml`
- Removed `File::Temp` dependency from test requirements (no longer needed for temporary file generation)
- Removed `File::Temp` from GitHub Actions test dependency installation

## Implementation Details
- The test fixture contains the same YAML structure that was previously generated inline
- Using a fixture file makes the test data more explicit and easier to modify without touching test logic
- Simplifies the test code by eliminating file handle management and temporary file cleanup

https://claude.ai/code/session_01MvtdY1A1j1v3NSwr4vUnAJ