### PR TITLE
fix: declare Test::More in cpanfile and remove redundant CI install step

### DIFF
--- a/.github/workflows/test-on-ubuntu.yml
+++ b/.github/workflows/test-on-ubuntu.yml
@@ -11,9 +11,6 @@ jobs:
       run: |
         sudo apt install -y perl cpanminus
         sudo cpanm --installdeps .
-    - name: Install test dependencies
-      run: |
-        sudo cpanm Test::More
     - name: Run unit tests
       run: |
         prove -lv tests/

--- a/cpanfile
+++ b/cpanfile
@@ -7,5 +7,5 @@ requires 'Try::Tiny', '0.32';
 
 on 'test' => sub {
     requires 'FindBin',    '1.54';
-    requires 'Test::More', '0';
+    requires 'Test::More', '1.302222';
 }

--- a/cpanfile
+++ b/cpanfile
@@ -6,5 +6,6 @@ requires 'Math::Random::Secure', '0.080001';
 requires 'Try::Tiny', '0.32';
 
 on 'test' => sub {
-    requires 'FindBin', '1.54';
+    requires 'FindBin',    '1.54';
+    requires 'Test::More', '0';
 }


### PR DESCRIPTION
## Summary

- Adds `Test::More` to the `on 'test'` block in `cpanfile` so it is covered by `cpanm --installdeps .`
- Removes the separate "Install test dependencies" step from `.github/workflows/test-on-ubuntu.yml`

## Before

```yaml
- name: Install dependencies
  run: |
    sudo apt install -y perl cpanminus
    sudo cpanm --installdeps .
- name: Install test dependencies
  run: |
    sudo cpanm Test::More
```

## After

```yaml
- name: Install dependencies
  run: |
    sudo apt install -y perl cpanminus
    sudo cpanm --installdeps .
```

All dependencies — runtime and test — are now declared in `cpanfile` and installed in a single step.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SXwV1TjAmjxADHAHgdLYf9)_