### PR TITLE
fix: import rand and irand from Math::Random::Secure to satisfy both SAST tools

### DIFF
--- a/lib/FuzzPM/Component/Mutator.pm
+++ b/lib/FuzzPM/Component/Mutator.pm
@@ -4,7 +4,7 @@ package FuzzPM::Component::Mutator {
     use bytes;
     use Getopt::Long;
     use Readonly;
-    use Math::Random::Secure qw(irand);
+    use Math::Random::Secure qw(rand irand);
 
     our $VERSION = '0.0.4';
     Readonly my $BYTE_BITS        => 8;


### PR DESCRIPTION
## Problem

Two SAST tools flag different things:

- **CodeQL** flags bare `rand()` call sites — fixed by using `irand()` instead
- **ZARN** flags the absence of a secure `rand` override — it recognises `use Math::Random::Secure;` as safe, but `qw(irand)` alone drops that override

PR #49 fixed CodeQL by switching to `qw(irand)`, but that caused ZARN alert #29 to re-open on `main`.

## Fix

```perl
use Math::Random::Secure qw(rand irand);
```

Importing `rand` explicitly restores the secure built-in override (ZARN is satisfied). The code continues to call `irand()` at every call site (CodeQL sees no bare `rand()` calls).

Single character change — one file, one line.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SXwV1TjAmjxADHAHgdLYf9)_